### PR TITLE
Add Website working group

### DIFF
--- a/active/website.md
+++ b/active/website.md
@@ -1,6 +1,6 @@
 # Website Working Group
 
-## Scope of responsibilities
+## Responsibilities
 
 This is a replacement of the current maintainer team @django/djangoproject-com-maintainters. The team will own maintenance of the website codebase, and liaise with the @django/ops-team for production infrastructure considerations.
 
@@ -8,12 +8,9 @@ The duties of the working group are:
 - Introduce new features on the website
 - Maintain and monitor the website 
 - Help to make the website accessible to all
-
-
-### Delegated responsibilities:
 - Members propose, triage, analize, discuss and implement new features
 - Members triage the project’s issues and pull requests.
-- Member maintain and monitor the website including updating versions.
+- Members maintain and monitor the website including updating versions.
 - Mentor new contributors to the website.
 - Run or support djangoproject.com sessions in DjangoCon sprints.
 - Chair, Co-Chair and Board Liaison can sign off on new features.
@@ -40,6 +37,11 @@ The duties of the working group are:
 
 Members must have interest in Django and should be able to work with Django. Members must go through [contributing](https://github.com/django/djangoproject.com/blob/main/README.rst) to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
 
+### Access granting and deployment
+Initial onboarding phase where only Chair and Co-Chair have permissions to merge. After onboarding of 6 months, other group members who have proven their expertise will be granted merge permissions at the discretion of the chair and co-chair. Ops team will retain access, and in case there are site infrastructure issues, would be able to restrict permissions. Process can be reviewed in the future with the ops team if needed.
+
+The deployment of the website will be done via a ping via @django/ops-team on the pull request to deploy the branch.
+
 ### How do people who want to join sign up / volunteer / express interest?
 Individuals can express interest by opening a PR to this working group repository, using a template, adding their names in the list of members.
 
@@ -55,7 +57,7 @@ Sums may be provided for specific activities (e.g. external consultancy, graphic
 
 ## Communications
 - Private channel in the DSF slack
-- A mailing list that we'll create, `website-wg@djangoproject.com`
+- The Django forum sub-section "Website" of Django Internals
 
 ## Reporting
 

--- a/active/website.md
+++ b/active/website.md
@@ -24,7 +24,6 @@ The duties of the working group are:
 - Co-Chair: TBA
 - Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): Thibaud Colas
 - Other members:
-    - Jacob Kaplan-Moss
     - Sarah Abderemane
     - Eric Sherman
     - Mark Walker

--- a/active/website.md
+++ b/active/website.md
@@ -24,7 +24,6 @@ The duties of the working group are:
 - Co-Chair: Saptak Sengupta
 - Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): Sarah Abderemane
 - Other members:
-    - Sarah Abderemane
     - Eric Sherman
     - Mark Walker
     - Jason Judkins

--- a/active/website.md
+++ b/active/website.md
@@ -39,7 +39,7 @@ The duties of the working group are:
 
 ### Who is eligible to join? Any volunteer, or are there specific requirements?
 
-Members must have interest in Django and should be able to work with Django. Most importantly members must be willing to adhere to Django's [Code of Conduct](https://www.djangoproject.com/conduct/) . Members must be well versed with the process of contributing to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
+Members must have interest in Django and should be able to work with Django. Members must be well versed with the process of contributing to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
 
 ### How do people who want to join sign up / volunteer / express interest?
 Individuals can express interest by emailing to the working group mailing list at `website-wg@djangoproject.com` 

--- a/active/website.md
+++ b/active/website.md
@@ -32,8 +32,6 @@ The duties of the working group are:
     - Tobias McNulty
     - Ron Maravanyika
 
-
-
 ## Future membership
 
 ### Who is eligible to join? Any volunteer, or are there specific requirements?

--- a/active/website.md
+++ b/active/website.md
@@ -48,7 +48,9 @@ Members join the group for one year term. At the end of this term, they need to 
 a member of the group.
 
 ## Budget
-No allocated budget
+No allocated budget.
+
+Sums may be provided for specific activities (e.g. external consultancy, graphic work, use of platforms, ...) subject to approval by the DSF board.
 
 ## Communications
 - Private channel in the DSF slack

--- a/active/website.md
+++ b/active/website.md
@@ -8,6 +8,7 @@ The duties of the working group are:
 - Introduce new features on the website
 - Maintain and monitor the website 
 - Ensure that information on the website is accurate 
+- Help to make the website accessible to all
 
 
 ### Delegated responsibilities:

--- a/active/website.md
+++ b/active/website.md
@@ -31,7 +31,7 @@ The duties of the working group are:
     - Sanyam Khurana
     - Tobias McNulty
     - Ron Maravanyika
-    - alexgmin Alex
+    - Alex Gómez
 
 ## Future membership
 

--- a/active/website.md
+++ b/active/website.md
@@ -22,7 +22,7 @@ The duties of the working group are:
 
 - Chair: TBA
 - Co-Chair: TBA
-- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): Thibaud Colas
+- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): TBA
 - Other members:
     - Sarah Abderemane
     - Eric Sherman

--- a/active/website.md
+++ b/active/website.md
@@ -2,7 +2,7 @@
 
 ## Scope of responsibilities
 
-This working group will manage Django's official website, **djangoproject.com** on behalf of the Django Software Foundation
+This is a replacement of the current maintainer team @django/djangoproject-com-maintainters. The team will own maintenance of the website codebase, and liaise with the @django/ops-team for production infrastructure considerations.
 
 The duties of the working group are:
 - Introduce new features on the website

--- a/active/website.md
+++ b/active/website.md
@@ -22,10 +22,9 @@ The duties of the working group are:
 
 - Chair: TBA
 - Co-Chair: TBA
-- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): TBA
+- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): Thibaud Colas
 - Other members:
     - Jacob Kaplan-Moss
-    - Thibaud Colas
     - Sarah Abderemane
     - Eric Sherman
     - Mark Walker
@@ -41,7 +40,7 @@ The duties of the working group are:
 
 ### Who is eligible to join? Any volunteer, or are there specific requirements?
 
-Members must have interest in Django and must be willing to work with Django. We welcome all experience levels, we also welcome first time contributors. 
+Members must have interest in Django and should be able to work with Django. Most importantly members must be willing to adhere to Django's [Code of Conduct](https://www.djangoproject.com/conduct/) . Members must be well versed with the process of contributing to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
 
 ### How do people who want to join sign up / volunteer / express interest?
 TBA

--- a/active/website.md
+++ b/active/website.md
@@ -14,7 +14,7 @@ The duties of the working group are:
 ### Delegated responsibilities:
 - Members can work on bugs
 - Members triage the project’s issues and pull requests.
-- Member can maintain and monitor the website including updating versions
+- Member maintain and monitor the website including updating versions
 - Mentor new contributors to the website
 - Chair, Co-Chair and Board Liaison can sign off on new features
 

--- a/active/website.md
+++ b/active/website.md
@@ -55,4 +55,7 @@ No allocated budget
 - A mailing list that we'll create, `website-wg@djangoproject.com`
 
 ## Reporting
-We'll email a written report to the board every quarter.
+
+We'll create a changelog file in the repository with all changes, using the https://keepachangelog.com format, whee to track all the regular changes 
+
+For special projects (e.g. theme redesign) we'll choose specific projects or reporting tools.

--- a/active/website.md
+++ b/active/website.md
@@ -53,7 +53,7 @@ a member of the group.
 ## Budget
 No allocated budget
 
-## Comms
+## Communications
 - Private channel in the DSF slack
 - A mailing list that we'll create, `website-wg@djangoproject.com`
 

--- a/active/website.md
+++ b/active/website.md
@@ -42,7 +42,7 @@ The duties of the working group are:
 Members must have interest in Django and should be able to work with Django. Most importantly members must be willing to adhere to Django's [Code of Conduct](https://www.djangoproject.com/conduct/) . Members must be well versed with the process of contributing to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
 
 ### How do people who want to join sign up / volunteer / express interest?
-TBA
+Individuals can express interest by emailing to the working group mailing list at `website-wg@djangoproject.com` 
 
 ### How will decisions on adding/removing members be handled?
 Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members; the WG will directly vote on new Chair/Co-Chairs.
@@ -52,10 +52,10 @@ a member of the group.
 
 
 ## Budget
-TBA
+No allocated budget
 
 ## Comms
 - A mailing list that we'll create, `website-wg@djangoproject.com`
 
 ## Reporting
-TBA
+We'll email a written report to the board every quarter.

--- a/active/website.md
+++ b/active/website.md
@@ -31,12 +31,13 @@ The duties of the working group are:
     - Sanyam Khurana
     - Tobias McNulty
     - Ron Maravanyika
+    - alexgmin Alex
 
 ## Future membership
 
 ### Who is eligible to join? Any volunteer, or are there specific requirements?
 
-Members must have interest in Django and should be able to work with Django. Members must be well versed with the process of contributing to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
+Members must have interest in Django and should be able to work with Django. Members must go through [contributing](https://github.com/django/djangoproject.com/blob/main/README.rst) to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
 
 ### How do people who want to join sign up / volunteer / express interest?
 Individuals can express interest by opening a PR to this working group repository, using a template, adding their names in the list of members.

--- a/active/website.md
+++ b/active/website.md
@@ -44,8 +44,7 @@ Individuals can express interest by opening a PR to this working group repositor
 ### How will decisions on adding/removing members be handled?
 Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members. The WG will vote for New Chair/Co-Chairs and decision to appoint will be based on gaining majority votes.
 
-Members join the group for one year term. At the end of this term, they need to opt into staying involved to keep being 
-a member of the group.
+Members join the group for one year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
 
 ## Budget
 No allocated budget.

--- a/active/website.md
+++ b/active/website.md
@@ -12,7 +12,6 @@ The duties of the working group are:
 
 
 ### Delegated responsibilities:
-- Members can work on bugs
 - Members triage the project’s issues and pull requests.
 - Member maintain and monitor the website including updating versions
 - Mentor new contributors to the website

--- a/active/website.md
+++ b/active/website.md
@@ -39,7 +39,7 @@ The duties of the working group are:
 Members must have interest in Django and should be able to work with Django. Members must be well versed with the process of contributing to **djangoproject.com** or at least willing to be guide. We welcome all experience levels, we also welcome first time contributors. 
 
 ### How do people who want to join sign up / volunteer / express interest?
-Individuals can express interest by emailing to the working group mailing list at `website-wg@djangoproject.com` 
+Individuals can express interest by opening a PR to this working group repository, using a template, adding their names in the list of members.
 
 ### How will decisions on adding/removing members be handled?
 Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members. The WG will vote for New Chair/Co-Chairs and decision to appoint will be based on gaining majority votes.

--- a/active/website.md
+++ b/active/website.md
@@ -1,0 +1,63 @@
+# Website Working Group
+
+## Scope of responsibilities
+
+This working group will manage Django's official website, **djangoproject.com** on behalf of the Django Software Foundation
+
+The duties of the working group are:
+- Introduce new minor features on the website
+- Maintain and monitor the website 
+- Ensure that information on the website is accurate 
+
+
+### Delegated responsibilities:
+- Chair, Co-chair and Board Liaison can make final decision of  sections of the website that might not conform with DSF's CoC.
+- Members can work on bugs
+- Members can tag,label and respond to issues.
+- Member can maintain and monitor the website including updating versions
+- Mentor new contributors to the website
+- Chair, Co-Chair and Board Liaison can sign off on new features
+
+## Initial membership
+
+- Chair: TBA
+- Co-Chair: TBA
+- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): TBA
+- Other members:
+    - Jacob Kaplan-Moss
+    - Thibaud Colas
+    - Sarah Abderemane
+    - Eric Sherman
+    - Mark Walker
+    - Jason Judkins
+    - Paolo Melchiorre
+    - Sanyam Khurana
+    - Tobias McNulty
+    - Ron Maravanyika
+
+
+
+## Future membership
+
+### Who is eligible to join? Any volunteer, or are there specific requirements?
+
+Members must have interest in Django and must be willing to work with Django. We welcome all experience levels, we also welcome first time contributors. 
+
+### How do people who want to join sign up / volunteer / express interest?
+TBA
+
+### How will decisions on adding/removing members be handled?
+Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members; the WG will directly vote on new Chair/Co-Chairs.
+
+Members join the group for a 2 year term. At the end of this term, they need to opt into staying involved to keep being 
+a member of the group.
+
+
+## Budget
+TBA
+
+## Comms
+- A mailing list that we'll create, `website-wg@djangoproject.com`
+
+## Reporting
+TBA

--- a/active/website.md
+++ b/active/website.md
@@ -13,7 +13,7 @@ The duties of the working group are:
 
 ### Delegated responsibilities:
 - Members can work on bugs
-- Members can tag,label and respond to issues.
+- Members triage the project’s issues and pull requests.
 - Member can maintain and monitor the website including updating versions
 - Mentor new contributors to the website
 - Chair, Co-Chair and Board Liaison can sign off on new features

--- a/active/website.md
+++ b/active/website.md
@@ -49,7 +49,6 @@ Direct membership: new members may self-nominate; the WG will vote (50%+1) to ap
 Members join the group for one year term. At the end of this term, they need to opt into staying involved to keep being 
 a member of the group.
 
-
 ## Budget
 No allocated budget
 

--- a/active/website.md
+++ b/active/website.md
@@ -56,6 +56,7 @@ a member of the group.
 No allocated budget
 
 ## Comms
+- Private channel in the DSF slack
 - A mailing list that we'll create, `website-wg@djangoproject.com`
 
 ## Reporting

--- a/active/website.md
+++ b/active/website.md
@@ -5,7 +5,7 @@
 This working group will manage Django's official website, **djangoproject.com** on behalf of the Django Software Foundation
 
 The duties of the working group are:
-- Introduce new minor features on the website
+- Introduce new features on the website
 - Maintain and monitor the website 
 - Ensure that information on the website is accurate 
 

--- a/active/website.md
+++ b/active/website.md
@@ -12,7 +12,6 @@ The duties of the working group are:
 
 
 ### Delegated responsibilities:
-- Chair, Co-chair and Board Liaison can make final decision of  sections of the website that might not conform with DSF's CoC.
 - Members can work on bugs
 - Members can tag,label and respond to issues.
 - Member can maintain and monitor the website including updating versions

--- a/active/website.md
+++ b/active/website.md
@@ -20,9 +20,9 @@ The duties of the working group are:
 
 ## Initial membership
 
-- Chair: TBA
-- Co-Chair: TBA
-- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): TBA
+- Chair: Sarah Abderemane
+- Co-Chair: Saptak Sengupta
+- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): Sarah Abderemane
 - Other members:
     - Sarah Abderemane
     - Eric Sherman

--- a/active/website.md
+++ b/active/website.md
@@ -13,10 +13,10 @@ The duties of the working group are:
 
 ### Delegated responsibilities:
 - Members triage the project’s issues and pull requests.
-- Member maintain and monitor the website including updating versions
-- Mentor new contributors to the website
+- Member maintain and monitor the website including updating versions.
+- Mentor new contributors to the website.
 - Run or support djangoproject.com sessions in DjangoCon sprints.
-- Chair, Co-Chair and Board Liaison can sign off on new features
+- Chair, Co-Chair and Board Liaison can sign off on new features.
 
 ## Initial membership
 

--- a/active/website.md
+++ b/active/website.md
@@ -32,6 +32,7 @@ The duties of the working group are:
     - Tobias McNulty
     - Ron Maravanyika
     - Alex Gómez
+    - Storm Heg
 
 ## Future membership
 

--- a/active/website.md
+++ b/active/website.md
@@ -15,6 +15,7 @@ The duties of the working group are:
 - Members triage the project’s issues and pull requests.
 - Member maintain and monitor the website including updating versions
 - Mentor new contributors to the website
+- Run or support djangoproject.com sessions in DjangoCon sprints.
 - Chair, Co-Chair and Board Liaison can sign off on new features
 
 ## Initial membership
@@ -44,9 +45,9 @@ Members must have interest in Django and should be able to work with Django. Mos
 Individuals can express interest by emailing to the working group mailing list at `website-wg@djangoproject.com` 
 
 ### How will decisions on adding/removing members be handled?
-Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members; the WG will directly vote on new Chair/Co-Chairs.
+Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members. The WG will vote for New Chair/Co-Chairs and decision to appoint will be based on gaining majority votes.
 
-Members join the group for a 2 year term. At the end of this term, they need to opt into staying involved to keep being 
+Members join the group for one year term. At the end of this term, they need to opt into staying involved to keep being 
 a member of the group.
 
 

--- a/active/website.md
+++ b/active/website.md
@@ -7,7 +7,6 @@ This is a replacement of the current maintainer team @django/djangoproject-com-m
 The duties of the working group are:
 - Introduce new features on the website
 - Maintain and monitor the website 
-- Ensure that information on the website is accurate 
 - Help to make the website accessible to all
 
 

--- a/active/website.md
+++ b/active/website.md
@@ -12,6 +12,7 @@ The duties of the working group are:
 
 
 ### Delegated responsibilities:
+- Members propose, triage, analize, discuss and implement new features
 - Members triage the project’s issues and pull requests.
 - Member maintain and monitor the website including updating versions.
 - Mentor new contributors to the website.


### PR DESCRIPTION
Based on the conversation on issue #2. I have created the initial proposal for the website working group.

- I have proposal for the duties that the group is willing to take and Liaison can add any other responsibilities l might have missed.
- I have added members that have accepted from the list of maintainers and those that showed interest, i will reach-out to the current maintainers of djangoproject.com for their confirmation.
- All aspects of the proposal can still be discuss 
- @thibaudcolas agreed to take this to the board for approval as per the conversation
- Chair and Co-Chair to be selected by members.
- I didn't have visibility of the Ops-Team and their responsibilities but we might need to add the team as members, @thibaudcolas perhaps you can help