### PR TITLE
Update DjangoCon Europe wg details

### DIFF
--- a/active/dceu.md
+++ b/active/dceu.md
@@ -10,9 +10,13 @@ Delegated responsibilities TBD.
 
 - Chair: TBD
 - Co-Chair: TBD
-- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): TBD
-- Other members: TBD
-
+- Board Liaison: Çağıl Uluşahin Sönmez  
+- Other members:
+    Becky Smith
+    Benjamin Balder Bach
+    Raphael Michel
+    Tobias Kunze
+                         
 ## Future membership
 
 Membership is open to former organizers of DjangoCon EUs. Contact TBD if this is you and you want to join. [Contact the board](https://www.djangoproject.com/contact/foundation/) to express interest.
@@ -25,7 +29,9 @@ TBD
 
 ## Comms
 
-TBD
+The team will operate via a Google Group, reachable via european-organizers-support@djangoproject.com. There might be additional more synchronous communication (e.g. Slack or Discord) if needed.
+
+The team will also set up a collection of data and information, in something like a Google Drive folder. A static informational website might follow at a later date.
 
 ## Reporting
 

--- a/active/dceu.md
+++ b/active/dceu.md
@@ -14,12 +14,13 @@ Delegated responsibilities TBD.
 - Other members:
     Becky Smith
     Benjamin Balder Bach
+    Iacopo Spalletti
     Raphael Michel
     Tobias Kunze
                          
 ## Future membership
 
-Membership is open to former organizers of DjangoCon EUs. Contact TBD if this is you and you want to join. [Contact the board](https://www.djangoproject.com/contact/foundation/) to express interest.
+Membership is open to former organizers of DjangoCon EUs. Questions about membership can be directed to european-organizers-support@djangoproject.com. [Contact the board](https://www.djangoproject.com/contact/foundation/) to express interest.
 
 Membership is self-managed: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members; the WG will directly vote on new Chair/Co-Chairs.
 


### PR DESCRIPTION
Following the frank conversation of better supporting European organizers Tobias put together a proposal for the structure and functioning of the committee to realize the support role. 

Changes here is updating the wg details with Tobias's proposal.