### PR TITLE
Update CoC WG membership

### DIFF
--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -8,14 +8,15 @@ See https://github.com/django/code-of-conduct for full details.
 
 ## Membership
 
-- Chair: Brian Moloney
+<!-- Keep the membership in sync between the GitHub team, https://github.com/django/code-of-conduct/blob/main/membership.md, https://github.com/django/dsf-working-groups/blob/main/active/code-of-conduct.md, https://www.djangoproject.com/foundation/committees/ -->
+
+- Chair: None
 - Board Liaison: DSF President (currently Chaim Kirby)
 - Other members:
+  - Jay Miller
+  - Dan Ryan
   - Jeff Triplett
-  - Olumide Bakare
-  - Joseph V. Cardenas
-  - Michael Clark
-  - Tibbs Hefflin
+  - Thibaud Colas
 
 ## Future membership
 

--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -8,13 +8,14 @@ See https://github.com/django/code-of-conduct for full details.
 
 ## Membership
 
-- Chair: None
+- Chair: Brian Moloney
 - Board Liaison: DSF President (currently Chaim Kirby)
 - Other members:
-  - Jay Miller
-  - Dan Ryan
   - Jeff Triplett
-  - Thibaud Colas
+  - Olumide Bakare
+  - Joseph V. Cardenas
+  - Michael Clark
+  - Tibbs Hefflin
 
 ## Future membership
 

--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -8,14 +8,13 @@ See https://github.com/django/code-of-conduct for full details.
 
 ## Membership
 
-- Chair: Brian Moloney
+- Chair: None
 - Board Liaison: DSF President (currently Chaim Kirby)
 - Other members:
+  - Jay Miller
+  - Dan Ryan
   - Jeff Triplett
-  - Olumide Bakare
-  - Joseph V. Cardenas
-  - Michael Clark
-  - Tibbs Hefflin
+  - Thibaud Colas
 
 ## Future membership
 


### PR DESCRIPTION
See [Update Code of Conduct team #45](https://github.com/django/code-of-conduct/issues/45). I’ll merge this one right away so we don’t have PRs open everywhere, and update again when we finalize the membership / determine a chair.