### PR TITLE
Update working group definitions to allow for teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About working groups
 
-Working groups and teams (will be referred to as working groups only) are the primary way work gets done at the DSF. The DSF Board and/or Steering Council delegates certain powers to working groups, which can then act on behalf of the DSF without Board votes/approvals on every specific item. For example, a Grants Working Group could have authority to directly issue financial grants, subject to certain limits, without the need for the full Board to approve each individual grant.
+Working groups and teams (will be referred to as working groups only) are groups of volunteers who work for the DSF or the Django framework itself. The DSF Board and/or Steering Council can delegate certain powers to working groups, which can then act on their behalf without Board/ Steering Council votes/approvals on every specific item. For example, a Grants Working Group could have authority to directly issue financial grants, subject to certain limits, without the need for the full Board to approve each individual grant.
 
 ## Joining a Working Group
 
@@ -18,7 +18,7 @@ Want to help out? Yay! Each working group's charter, linked below, spells out th
 
 ## Forming a new Working Group
 
-If you have an idea for a new Working Group, it's a good idea to discuss it with some/all of the DSF board and/or Steering Council ahead of a formal proposal. Remember, you'll be proposing that the Board and/or Steering Council delegate some of its powers to this new group, so socializing the proposal before you make it can help make sure your request doesn't come as a surprise. The [list of current board members is here](https://www.djangoproject.com/foundation/), and you can [contact the board as a whole using this form here](https://www.djangoproject.com/contact/foundation/). The [list of current Steering Council members is here](https://www.djangoproject.com/foundation/teams/#steering-council-team), and you can [contact the Steering Council as a whole on the forum with the `@steering_council` tag](https://forum.djangoproject.com).
+If you have an idea for a new Working Group, it's a good idea to discuss it with some/all of the DSF board and/or Steering Council ahead of a formal proposal. Remember, you may propose that the Board and/or Steering Council delegate some of its powers to this new group, so socializing the proposal before you make it can help make sure your request doesn't come as a surprise. The [list of current board members is here](https://www.djangoproject.com/foundation/), and you can [contact the board as a whole using this form here](https://www.djangoproject.com/contact/foundation/). The [list of current Steering Council members is here](https://www.djangoproject.com/foundation/teams/#steering-council-team), and you can [contact the Steering Council as a whole on the forum with the `@steering_council` tag](https://forum.djangoproject.com).
 
 ### Proposing a working group
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About working groups
 
-Working groups are the primary way work gets done at the DSF. The DSF Board delegates certain powers to working groups, which can then act on behalf of the DSF without Board votes/approvals on every specific item. For example, a Grants Working Group could have authority to directly issue financial grants, subject to certain limits, without the need for the full Board to approve each individual grant.
+Working groups and teams (will be referred to as working groups only) are the primary way work gets done at the DSF. The DSF Board and/or Steering Council delegates certain powers to working groups, which can then act on behalf of the DSF without Board votes/approvals on every specific item. For example, a Grants Working Group could have authority to directly issue financial grants, subject to certain limits, without the need for the full Board to approve each individual grant.
 
 ## Joining a Working Group
 
@@ -18,11 +18,11 @@ Want to help out? Yay! Each working group's charter, linked below, spells out th
 
 ## Forming a new Working Group
 
-If you have an idea for a new Working Group, it's a good idea to discuss it with some/all of the DSF board ahead of a formal proposal. Remember, you'll be proposing that the Board delegate some of its powers to this new group, so socializing the proposal before you make it can help make sure your request doesn't come as a surprise. The [list of current board members is here](https://www.djangoproject.com/foundation/), and you can [contact the board as a whole using this form here](https://www.djangoproject.com/contact/foundation/).
+If you have an idea for a new Working Group, it's a good idea to discuss it with some/all of the DSF board and/or Steering Council ahead of a formal proposal. Remember, you'll be proposing that the Board and/or Steering Council delegate some of its powers to this new group, so socializing the proposal before you make it can help make sure your request doesn't come as a surprise. The [list of current board members is here](https://www.djangoproject.com/foundation/), and you can [contact the board as a whole using this form here](https://www.djangoproject.com/contact/foundation/). The [list of current Steering Council members is here](https://www.djangoproject.com/foundation/teams/#steering-council-team), and you can [contact the Steering Council as a whole on the forum with the `@steering_council` tag](https://forum.djangoproject.com).
 
 ### Proposing a working group
 
-Once you're ready to propose a working group, start the process by creating a pull request, adding your new working group's charter. You probably want to use [the provided template](template.md) as a starting point.
+Once you're ready to propose a working group, start the process by creating a pull request, adding your new working group's charter. You probably want to use [the working group template](template.md) or the [team template](team-template.md) as a starting point.
 
 Don't worry about getting it all in the first pass; you're welcome to leave some fields as "todo", and come back and edit the PR later to add that info.
 
@@ -34,8 +34,9 @@ Ultimately, the information that needs to be in the charter is:
   - What actions are you proposing the WG be allowed to take directly?
   - Which actions will the WG take back to the Board for votes?
 - **Initial membership** - who will be in this working group when it's first created?
-  - **Board of liaison** - the person will be the bridge between the DSF board and the working group. It will be someone who will keep the vision of the board in the working group and have the same rights as a member of the working group.  
-  - **Every working group must have at least one active Board member**. It's best if you already know who this is. It's OK if you don't, but if nobody from the Board volunteers, we can't create your working group. We'll refer to this person as the WG's "Board Liaison".
+  - **Board of liaison** - the person will be the bridge between the DSF board and the working group. It will be someone who will keep the vision of the board in the working group and have the same rights as a member of the working group.
+  - **Steering Council liaison** - the person will be the bridge between the Steering Council and the working group. It will be someone who will keep the vision of the Steering Council in the working group and have the same rights as a member of the working group. This is only for teams and is only optional.
+  - **Every working group should have at least one active Board member**. It's best if you already know who this is. It's OK if you don't, but if nobody from the Board volunteers, we can't create your working group. We'll refer to this person as the WG's "Board Liaison". A Board Liason is optional for teams and required for working groups.
   - **Every working group must have a Chair and Co-Chair**, please indicate who that'll be.
   - A good size for a Working Group is around 3-7 people. It's fine if you want to fall outside this range, but you may be asked about the relatively smaller/larger size.
 - **Future membership** - how will membership be handled once the group is operational?
@@ -50,7 +51,7 @@ Ultimately, the information that needs to be in the charter is:
 
 ### Decision-making
 
-After your proposal is complete, notify the board, via your board liaison, that it's ready to be reviewed.
+After your proposal is complete, notify the board and/or Steering Council, via your liaison(s), that it's ready to be reviewed.
 
 The board will vote on your working group, and either let you know that it's been approved, or give you feedback.
 
@@ -79,7 +80,7 @@ WGs may be spun down for many reasons. The common ones are that the WG has fulfi
 There are also several reasons why a WG may be forced to shut down:
 
 - There aren't enough members to sustain the group. A WG must have, at a minimum, two members (Chair and Co-Chair), and one Board member. If membership falls below those levels, and no replacements can be found, the WG will be automatically shut down.
-- The WG ceases reporting to the Board. A WG that misses two or more consecutive reporting periods in a row will generally be considered to be defunct and shut down by the Board (exceptions may be made).
+- The WG ceases reporting. A WG that misses two or more consecutive reporting periods in a row will generally be considered to be defunct and shut down by the Board (exceptions may be made).
 - If the Board believes a WG is no longer functional, for whatever reason, they may vote to shut it down.
 
 The process for spinning down a WG:

--- a/team-template.md
+++ b/team-template.md
@@ -1,0 +1,59 @@
+# Technical Team/WG Charter Template
+
+_This is a template charter for a technical team / working group. You'll need all the following for a proposal to be considered complete. See the [README](README.md) for more information on each field._
+
+## Scope of responsibilities
+
+Write a paragraph or a few bullet points describing the WG here.
+
+- What powers are you asking the board to delegate to you, if any?
+- What powers are you asking the Steering Council to delegate to you, if any?
+- What actions are you proposing the team/WG be allowed to take directly?
+- Which actions will the team/WG take back to the Board for votes, if any?
+- Which actions will the team/WG take back to the Steering Council for votes, if any?
+
+## Initial membership
+
+- Chair:
+- Co-Chair:
+- [Optional] Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair):
+- [Optional] Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair):
+- Other members:
+
+## Future membership
+
+Answer the following questions here:
+
+- Who is eligible to join? Any volunteer, or are there specific requirements?
+- How do people who want to join sign up / volunteer / express interest?
+- How will decisions on adding/removing members be handled?
+
+For the last question, we suggest picking one of the following:
+
+- Direct membership: new members may self-nominate; the team/WG will vote (50%+1) to approve/deny new members; the team/WG will directly vote on new Chair/Co-Chairs. (This is the appropriate model for most team/WGs).
+- Board-managed: new members may self-nominate, but must be voted in by the Board. The Board must approve changes to the Chair/Co-Chair. (This is the appropriate model for sensitive, community based teams/WGs, such as the Ops Team, or WGs with large budgets ($thousands/year).)
+- Steering Council-managed: new members may self-nominate, but must be voted in by the Steering Council. The Steering Council must approve changes to the Chair/Co-Chair. (This is the appropriate model for sensitive teams/WGs, such as the Mergers team.)
+
+## Budget
+
+- How much money or spending discretion do you need?
+- How do you want that money allocated -- e.g. once yearly, quarterly, etc.
+
+## Comms
+
+Where will discussions and activities take place?
+
+Suggestions:
+
+- A mailing list that we'll create, `some-wg@djangoproject.com`
+- The DSF Slack
+- The Django Discord server
+- The Forum
+
+Meetings: we also suggest synchronous meetings via Meet/Zoom/Whereby/etc at least monthly.
+
+## Reporting
+
+How and how often will the team/WG report back to the Steering Council and/or board?
+
+Suggestion: we'll post a report to the Forum [monthly/every two months/every quarter].

--- a/team-template.md
+++ b/team-template.md
@@ -5,6 +5,7 @@ _This is a template charter for a technical team / working group. You'll need al
 ## Scope of responsibilities
 
 Write a paragraph or a few bullet points describing the WG here.
+Please link any relevant documentation.
 
 - What powers are you asking the board to delegate to you, if any?
 - What powers are you asking the Steering Council to delegate to you, if any?


### PR DESCRIPTION
The primary changes are:

- Use "teams" phrase in README, but typically refer to them as working group (need input)
- Remove strict requirement for having a board liaison
- Allow for steering council only managed working groups/teams
- Adds a team template

This was an action item from the [Accessibility team meeting on 2025-03-27](https://forum.djangoproject.com/t/accessibility-team-meeting-notes/26133/25)