### PR TITLE
OCWG Liaison to the CoCWG nominated, Co-chair updated

### DIFF
--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -13,6 +13,7 @@ See https://github.com/django/code-of-conduct for full details.
 - Chair: Dan Ryan
 - Vice-Chair: Elena Williams
 - Board Liaison: DSF President (currently Thibaud Colas)
+- Online Communities WG Liaison: Natalia Bidart
 - Other members:
   - Jay Miller
   - Jeff Triplett
@@ -24,6 +25,8 @@ Membership is open to volunteers. To volunteer to join the working group, email 
 Membership is self-managed: volunteers are screened and inducted by the current WG membership. The membership likewise elects its own chair (via 50%+ voting). See https://github.com/django/code-of-conduct/blob/main/membership.md for more details.
 
 The DSF President is always a member of the CoC WG, and its board liaison.
+
+The Online Communities WG Liason is a voting member of this working group that is chosen by the OCWG from their members.
 
 ## Budget
 

--- a/active/online-community.md
+++ b/active/online-community.md
@@ -40,12 +40,12 @@ With regards to Django Software Foundation responsibilities and resources, the m
 ## Initial membership
 
 - Chair: Andrew Miller
-- Co-Chair: Natalia Bidart
+- Co-Chair: Ben Cardy
 - Board Liaison: Tom Carrick
 - CoC Liaison: Dan Ryan
 - Other members:
   - Patryk Bratkowski
-  - Ben Cardy
+  - Natalia Bidart
 
 
 ## Future membership


### PR DESCRIPTION
This PR superseds #30 

The OCWG had our first meeting last week and Natalia volunteered to be the CoC WG Liaison. In light of that we switched to Ben being Co-chair so Natalia isn't wearing too many hats!