### PR TITLE
Add events support group charter first draft

### DIFF
--- a/active/events-support.md
+++ b/active/events-support.md
@@ -13,7 +13,7 @@ The group supports organizers of Django-related events globally, including Djang
 For DjangoCon events, the working group will:
 
 - Liaise with DEFNA (Django Events Foundation North America) who oversee DjangoCon US.
-- Manage and execute the Call for Organizers process for DjangoCon Europe, providing recommendations to the DSF board for final approval.
+- Manage and execute the Call for Organizers process for DjangoCon Europe, providing the DSF board with both a non-binding list of general criteria AND reviews of concrete proposals.
 - Assist DjangoCon Europe organizers with event planning, logistics, and execution.
 - Work with DjangoCon Africa organizers to make this event sustainable.
 - Work with the Social Media Working Group to promote events


### PR DESCRIPTION
New group proposed to replace and broaden the existing [DjangoCon Europe support](https://github.com/django/dsf-working-groups/blob/main/active/dceu.md) group. Key differences:

- Scope to support all Django-related events
- New members
- Open to all (see #1)

Similarities:

- DjangoCon Europe organizer proposals voting remains with the Board
- Event grants requests remains with the Board

---

**We’re looking for members now**. There is some urgency in getting this up and running as we have a lot of ongoing activities that could use support, namely:

- DjangoCon Africa coming up in August
- DjangoCon Europe 2026 organizing kickstart
- DjangoCon Europe 2027 call for organizers