### PR TITLE
Add security team charter.

### DIFF
--- a/active/security.md
+++ b/active/security.md
@@ -1,0 +1,93 @@
+# Security Team
+
+## Scope of responsibilities
+
+The security team is responsible for [Django’s security policies](https://docs.djangoproject.com/en/dev/internals/security/). This includes:
+
+- Reviewing security reports via security@djangoproject.com
+- Evaluating and patching confirmed security issues
+- Communicating with reporters
+- Communicating with the public about security releases
+- Communicating with operating-system vendors and other distributors of Django
+
+## Initial membership
+
+- Chair:
+- Co-Chair:
+- Report triagers: 
+- Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair): Carlton Gibson
+- Other members:
+  - Adam Johnson
+  - Carlton Gibson
+  - Jacob Walls
+  - Jake Howard
+  - James Bennett
+  - Mariusz Felisiak
+  - Markus Holtermann
+  - Michael Manfre
+  - Natalia Bidart
+  - Paul McMillan
+  - Sarah Boyce
+  - Shai Berger
+  - Simon Charette
+ 
+Note: The DSF Board President has access to the security mailing list, but does not otherwise participate in the team’s activities. This is mentioned for the sake of transparency.
+ 
+### Role definitions
+
+- Chair / Co-Chair: Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities.
+- Report triagers: These team members are responsible for acknowleding and triaging reports initially to determine likelyhood of security concern and severity.
+ 
+## Future membership
+
+The team does not have a fixed size. The team decides when new members are needed. New members are chosen from a list of volunteers. If there are no qualified volunteers the team will place an advertisement on the Django website.
+
+Members must opt-in to remain on the team on an annual basis. They may also leave for any reason.
+
+Members can also be removed by:
+
+- Becoming disqualified by the Code of Conduct working group
+- A vote of the Steering Council
+- The full consensus of the rest of the Security Team
+
+### Membership requirements
+
+Members should possess some  knowledge of the following topics, but not necessarily all of them.
+
+- Building Django applications
+- Contributing to Django
+- Web applications
+- Web security
+- Software security
+
+### How to join
+
+Any person can volunteer to join the security team by submitting a Google Form (TODO: Create link). The team/WG will vote (50%+1) to approve/deny new members; the team/WG will directly vote on new Chair/Co-Chairs.
+
+The application should include the following:
+
+- Why do you want to join the team?
+- What is your history of using Django as a developer?
+- What is your history of contributing to Django?
+- What security experience do you bring that would be helpful to the team?
+
+(TODO: Define cadence of reviewing applications)
+
+## Budget
+
+No budget is required at this time. This will be reviewed at least annually.
+Any changes to the budget may be requested from the board.
+
+## Comms
+
+The team has discussions in two places:
+
+1. Formal and sensitive discussions on the mailing list: security@djangoproject.com
+2. Informal and team discussions on the DSF Slack in the private channel `#security-team`
+
+## Reporting
+
+The team has two responsibilities in regards to reporting to the Board and the Steering Council:
+
+1. Use [Django Release Announcements thread](https://forum.djangoproject.com/t/django-release-announcements/655/96) on the Forum to report security releases
+2. An annual report summarizing the team's activity, areas of concern, considerations for the future and any other relevant topics

--- a/active/security.md
+++ b/active/security.md
@@ -18,7 +18,7 @@ The Security Team is responsible for [Django’s security policies](https://docs
 - Chair:
 - Co-Chair:
 - Report triagers: 
-- Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair): Carlton Gibson
+- Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair): Frank Wiles
 - Other members:
   - Adam Johnson
   - Jacob Walls

--- a/active/security.md
+++ b/active/security.md
@@ -16,7 +16,7 @@ The Security Team is responsible for [Django’s security policies](https://docs
 
 ## Membership
 
-- Chair:
+- Chair: Natalia Bidart
 - Co-Chair:
 - Report triagers: 
 - Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair): Frank Wiles

--- a/active/security.md
+++ b/active/security.md
@@ -8,7 +8,7 @@ The Security Team is responsible for [Django’s security policies](https://docs
 
 - Reviewing security reports
 - Evaluating and developing fixes for confirmed security issues
-- Applying, backporting and releasing those fixes as patches and Django releases
+- Applying and backporting those fixes
 - Communicating with reporters
 - Communicating with the public about security releases
 - Communicating with operating-system vendors and other distributors of Django

--- a/active/security.md
+++ b/active/security.md
@@ -99,7 +99,7 @@ Any changes to the budget may be requested from the board.
 
 ## Comms
 
-The team has discussions in two places:
+The team has discussions in the following places:
 
 1. Formal and sensitive discussions on the mailing list: security@djangoproject.com
 2. Informal and team discussions on the DSF Slack in the private channel `#security-team`

--- a/active/security.md
+++ b/active/security.md
@@ -5,7 +5,8 @@
 The security team is responsible for [Django’s security policies](https://docs.djangoproject.com/en/dev/internals/security/). This includes:
 
 - Reviewing security reports via security@djangoproject.com
-- Evaluating and patching confirmed security issues
+- Evaluating and developing fixes for confirmed security issues
+- Applying, backporting and releasing those fixes as patches and Django releases
 - Communicating with reporters
 - Communicating with the public about security releases
 - Communicating with operating-system vendors and other distributors of Django
@@ -52,13 +53,14 @@ Members can also be removed by:
 
 ### Membership requirements
 
-Members should possess some  knowledge of the following topics, but not necessarily all of them.
+Members should possess some knowledge in most of the following topics:
 
 - Building Django applications
 - Contributing to Django
 - Web applications
 - Web security
 - Software security
+- Software performance
 
 ### How to join
 

--- a/active/security.md
+++ b/active/security.md
@@ -12,6 +12,7 @@ The Security Team is responsible for [Django’s security policies](https://docs
 - Communicating with reporters
 - Communicating with the public about security releases
 - Communicating with operating-system vendors and other distributors of Django
+- Maintaining the DSF's status as a CVE Numbering Authority (CNA) and casting votes (or abstaining) in CNA elections
 
 ## Membership
 

--- a/active/security.md
+++ b/active/security.md
@@ -1,8 +1,10 @@
 # Security Team
 
+The Security Team is the group of people who respond to security reports for the Django framework.
+
 ## Scope of responsibilities
 
-The security team is responsible for [Django’s security policies](https://docs.djangoproject.com/en/dev/internals/security/). This includes:
+The Security Team is responsible for [Django’s security policies](https://docs.djangoproject.com/en/dev/internals/security/). This includes:
 
 - Reviewing security reports via security@djangoproject.com
 - Evaluating and developing fixes for confirmed security issues
@@ -22,7 +24,6 @@ The security team is responsible for [Django’s security policies](https://docs
   - Carlton Gibson
   - Jacob Walls
   - Jake Howard
-  - James Bennett
   - Mariusz Felisiak
   - Markus Holtermann
   - Michael Manfre
@@ -37,7 +38,7 @@ Note: The DSF Board President has access to the security mailing list, but does 
 ### Role definitions
 
 - Chair / Co-Chair: Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities.
-- Report triagers: These team members are responsible for acknowleding and triaging reports initially to determine likelyhood of security concern and severity.
+- Report triagers: These team members are responsible for acknowledging and triaging reports initially to determine likelihood of security concern and severity.
  
 ## Future membership
 

--- a/active/security.md
+++ b/active/security.md
@@ -53,13 +53,12 @@ Every member can adopt and step back as a Report Triager as their schedule allow
 
 The responsibilities of a Report Triager are as follows:
 
-- Acknowledge incoming reports
-- Initial triage
-- Request help from experts if necessary
-- Complete triage
-- Facilitate hand-off with team member to own the report through resolution
-- For invalid reports, the following are included:
-    - Communicate with reporter
+- Acknowledge report received
+- Initial assessment
+- Request help from team/experts if necessary
+- Progress to resolution
+    - For valid reports, hand-off to team member to own the report
+    - For invalid reports, communicate with reporter
 
 ## Future membership
 

--- a/active/security.md
+++ b/active/security.md
@@ -21,7 +21,6 @@ The Security Team is responsible for [Django’s security policies](https://docs
 - Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair): Carlton Gibson
 - Other members:
   - Adam Johnson
-  - Carlton Gibson
   - Jacob Walls
   - Jake Howard
   - Mariusz Felisiak

--- a/active/security.md
+++ b/active/security.md
@@ -63,9 +63,17 @@ The responsibilities of a Report Triager are as follows:
 
 ## Future membership
 
-The team does not have a fixed size. The team decides when new members are needed. New members are chosen from a list of volunteers. If there are no qualified volunteers the team will place an advertisement on the Django website.
+The team manages its own membership by invitation. If the team needs to make a call for volunteers, it will be posted on the [djangoproject.com blog](https://www.djangoproject.com/weblog/) and the [Django Forum](https://forum.djangoproject.com). 
 
-Members must opt-in to remain on the team on an annual basis. They may also leave for any reason.
+The membership will operate as follows:
+
+- There is no upper limit to the team size
+- The team/WG will vote (50%+1) to approve/deny new member.
+- The team will directly vote on new Chair/Co-Chairs
+- All Django Fellows are automatically added to the Security team
+- A Django Fellow contract termination removes the person from the Security team
+- Each year, every non-Fellow member will need to reaffirm their membership with the team
+- A member can leave for any reason
 
 Members can also be removed by:
 
@@ -83,19 +91,6 @@ Members should possess some knowledge in most of the following topics:
 - Web security
 - Software security
 - Software performance
-
-### How to join
-
-Any person can volunteer to join the security team by submitting a Google Form (TODO: Create link). The team/WG will vote (50%+1) to approve/deny new members; the team/WG will directly vote on new Chair/Co-Chairs.
-
-The application should include the following:
-
-- Why do you want to join the team?
-- What is your history of using Django as a developer?
-- What is your history of contributing to Django?
-- What security experience do you bring that would be helpful to the team?
-
-(TODO: Define cadence of reviewing applications)
 
 ## Budget
 

--- a/active/security.md
+++ b/active/security.md
@@ -6,7 +6,7 @@ The Security Team is the group of people who respond to security reports for the
 
 The Security Team is responsible for [Django’s security policies](https://docs.djangoproject.com/en/dev/internals/security/). This includes:
 
-- Reviewing security reports via security@djangoproject.com
+- Reviewing security reports
 - Evaluating and developing fixes for confirmed security issues
 - Applying, backporting and releasing those fixes as patches and Django releases
 - Communicating with reporters

--- a/active/security.md
+++ b/active/security.md
@@ -13,7 +13,7 @@ The Security Team is responsible for [Django’s security policies](https://docs
 - Communicating with the public about security releases
 - Communicating with operating-system vendors and other distributors of Django
 
-## Initial membership
+## Membership
 
 - Chair:
 - Co-Chair:
@@ -33,12 +33,34 @@ The Security Team is responsible for [Django’s security policies](https://docs
   - Simon Charette
  
 Note: The DSF Board President has access to the security mailing list, but does not otherwise participate in the team’s activities. This is mentioned for the sake of transparency.
+
+Every member of the team is encouraged to participate in all aspects of the team, including reviewing security reports, developing fixes and communicating with reporters. The expectations for all team members are as follows:
+
+- Participate in the process for at least one security report a year
  
 ### Role definitions
 
-- Chair / Co-Chair: Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities.
-- Report triagers: These team members are responsible for acknowledging and triaging reports initially to determine likelihood of security concern and severity.
- 
+There are specific roles that have a higher level of expectations:
+
+- **Chair / Co-Chair:** Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities. The Chair and Co-Chair roles should be re-evaluated annually by the team.
+- **Report Triagers:** Acknowledge and triage initial reports and communicate with reporters.
+
+#### Report Triager
+
+These team members are responsible for acknowledging and triaging reports initially to determine likelihood of security concern and severity. As this is a volunteer role, the Fellows will support the triagers and when necessary, handle the initial triaging.
+
+Every member can adopt and step back as a Report Triager as their schedule allows.
+
+The responsibilities of a Report Triager are as follows:
+
+- Acknowledge incoming reports
+- Initial triage
+- Request help from experts if necessary
+- Complete triage
+- Facilitate hand-off with team member to own the report through resolution
+- For invalid reports, the following are included:
+    - Communicate with reporter
+
 ## Future membership
 
 The team does not have a fixed size. The team decides when new members are needed. New members are chosen from a list of volunteers. If there are no qualified volunteers the team will place an advertisement on the Django website.

--- a/active/security.md
+++ b/active/security.md
@@ -108,6 +108,7 @@ The team has discussions in two places:
 
 1. Formal and sensitive discussions on the mailing list: security@djangoproject.com
 2. Informal and team discussions on the DSF Slack in the private channel `#security-team`
+3. Monthly video-conference meetings
 
 ## Reporting
 

--- a/active/security.md
+++ b/active/security.md
@@ -8,21 +8,21 @@ The Security Team is responsible for [Django’s security policies](https://docs
 
 - Reviewing security reports
 - Evaluating and developing fixes for confirmed security issues
-- Applying and backporting those fixes
+- Applying and backporting those fixes in coordination with Mergers and Releasers
 - Communicating with reporters
 - Communicating with the public about security releases
-- Communicating with operating-system vendors and other distributors of Django
+- Maintaining a list of organizations to receive pre-notifications about security releases, and making these pre-notifications
 - Maintaining the DSF's status as a CVE Numbering Authority (CNA) and casting votes (or abstaining) in CNA elections
+- Issue CVEs for Django and projects under the Django organization
 
 ## Membership
 
 - Chair: Natalia Bidart
-- Co-Chair:
+- Co-Chair: Jacob Walls
 - Report triagers: 
 - Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair): Frank Wiles
 - Other members:
   - Adam Johnson
-  - Jacob Walls
   - Jake Howard
   - Mariusz Felisiak
   - Markus Holtermann
@@ -33,7 +33,7 @@ The Security Team is responsible for [Django’s security policies](https://docs
   - Shai Berger
   - Simon Charette
  
-Note: The DSF Board President has access to the security mailing list, but does not otherwise participate in the team’s activities. This is mentioned for the sake of transparency.
+Note: The DSF Board President has access to the designated reporting channels for governance oversight and legal accountability. This is a longstanding practice, noted here for transparency.
 
 Every member of the team is encouraged to participate in all aspects of the team, including reviewing security reports, developing fixes and communicating with reporters. The expectations for all team members are as follows:
 
@@ -43,7 +43,7 @@ Every member of the team is encouraged to participate in all aspects of the team
 
 There are specific roles that have a higher level of expectations:
 
-- **Chair / Co-Chair:** Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities. The Chair and Co-Chair roles should be re-evaluated annually by the team.
+- **Chair / Co-Chair:** Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities. The Chair and Co-Chair roles should be re-elected annually by the team. The details of the election procedure are left to the team.
 - **Report Triagers:** Acknowledge and triage initial reports and communicate with reporters.
 
 #### Report Triager
@@ -57,29 +57,49 @@ The responsibilities of a Report Triager are as follows:
 - Acknowledge report received
 - Initial assessment
 - Request help from team/experts if necessary
-- Progress to resolution
-    - For valid reports, hand-off to team member to own the report
-    - For invalid reports, communicate with reporter
+- For invalid reports, communicate with reporter
+- Optionally for valid reports, progress to resolution (e.g. create a PR to resolve the issue)
+
+At a minimum, a Report Triager is expected to:
+- Triage 1 report a month
+- Join 1 team meeting in a 6 months period
 
 ## Future membership
 
-The team manages its own membership by invitation. If the team needs to make a call for volunteers, it will be posted on the [djangoproject.com blog](https://www.djangoproject.com/weblog/) and the [Django Forum](https://forum.djangoproject.com). 
+Any DSF member may submit a nomination, including a self-nomination, to the team's mailing list (security@djangoproject.com).
+If the team needs to make a call for volunteers, it will be posted on the [djangoproject.com blog](https://www.djangoproject.com/weblog/) and the [Django Forum](https://forum.djangoproject.com). 
 
-The membership will operate as follows:
+Nominations are approved/rejected during the team meeting.
+Team members are encouraged to share their position via the mailing list before the meeting.
+A nomination is approved when at least one existing Security Team member votes in favor and no member objects.
+Note that there is no upper limit to the team size
 
-- There is no upper limit to the team size
-- The team/WG will vote (50%+1) to approve/deny new member.
-- The team will directly vote on new Chair/Co-Chairs
-- All Django Fellows are automatically added to the Security team
-- A Django Fellow contract termination removes the person from the Security team
-- Each year, every non-Fellow member will need to reaffirm their membership with the team
-- A member can leave for any reason
+New members, including new Fellows, complete a 3-month onboarding period during which all external communications (with reporters, vendors, or distributors) must be reviewed by an existing member before sending.
+This ensures each report is handled consistently and no valid reports are inadvertently dismissed.
 
-Members can also be removed by:
+As Django Fellows are contracted to deal with security reports, all Django Fellows are automatically added to the Security Team.
 
-- Becoming disqualified by the Code of Conduct working group
-- A vote of the Steering Council
-- The full consensus of the rest of the Security Team
+## Membership management
+
+Each year, every non-Fellow member will need to reaffirm their membership with the team
+A non-Fellow member can leave for any reason at any time
+
+### Reasons members can be removed from the team
+
+#### Inactivity
+
+If a member is inactive per this document’s definition, they should be removed from the team with a note of thanks and an open invitation to return.
+
+#### Security or malicious concerns
+
+If there is a credible security or malicious concern, a team member can report this in a private email to all other members.
+If at least 2 members (including the reporter) share this concern, the team must temporarily suspend access during an investigation, notifying the individual.
+A final decision (e.g., permanent removal) requires a vote from the DSF Board.
+
+#### Code of Conduct disqualification
+
+As an official Django space, the security team abides by the Code of Conduct.
+As per the [Code of Conduct Enforcement Ladder](https://github.com/django/code-of-conduct/blob/main/enforcement-ladder.md), members may be temporarily suspended or permanently banned from the security team following a Code of Conduct report.
 
 ### Membership requirements
 
@@ -102,12 +122,10 @@ Any changes to the budget may be requested from the board.
 The team has discussions in the following places:
 
 1. Formal and sensitive discussions on the mailing list: security@djangoproject.com
-2. Informal and team discussions on the DSF Slack in the private channel `#security-team`
+2. Informal and team discussions on the DSF Slack in the private channel `#security-private`
 3. Monthly video-conference meetings
+4. A private Github repository where patches are prepared
 
 ## Reporting
 
-The team has two responsibilities in regards to reporting to the Board and the Steering Council:
-
-1. Use [Django Release Announcements thread](https://forum.djangoproject.com/t/django-release-announcements/655/96) on the Forum to report security releases
-2. An annual report summarizing the team's activity, areas of concern, considerations for the future and any other relevant topics
+An annual report is shared with the Steering Council and the DSF Board summarizing the team's activity, areas of concern, considerations for the future and any other relevant topics.

--- a/active/security.md
+++ b/active/security.md
@@ -125,7 +125,7 @@ The team has discussions in the following places:
 1. Formal and sensitive discussions on the mailing list: security@djangoproject.com
 2. Informal and team discussions on the DSF Slack in the private channel `#security-private`
 3. Monthly video-conference meetings
-4. A private Github repository where patches are prepared
+4. A private Github repository to collect and triage all reports and to prepare patches
 
 ## Reporting
 

--- a/active/security.md
+++ b/active/security.md
@@ -45,6 +45,7 @@ There are specific roles that have a higher level of expectations:
 
 - **Chair / Co-Chair:** Responsible for coordinating the group, scheduling meetings, renewing the group’s membership, and ensuring that the group’s activities align with its scope and responsibilities. The Chair and Co-Chair roles should be re-elected annually by the team. The details of the election procedure are left to the team.
 - **Report Triagers:** Acknowledge and triage initial reports and communicate with reporters.
+- **Other Members:** Assist the Report Triagers when needed, for example when a report matches their area of expertise.
 
 #### Report Triager
 

--- a/active/security.md
+++ b/active/security.md
@@ -95,7 +95,7 @@ If a member is inactive per this document’s definition, they should be removed
 
 If there is a credible security or malicious concern, a team member can report this in a private email to all other members.
 If at least 2 members (including the reporter) share this concern, the team must temporarily suspend access during an investigation, notifying the individual.
-A final decision (e.g., permanent removal) requires a vote from the DSF Board.
+If the team can't arrive at a consensus, the decision can be escalated to the DSF Board.
 
 #### Code of Conduct disqualification
 

--- a/active/security.md
+++ b/active/security.md
@@ -82,8 +82,8 @@ As Django Fellows are contracted to deal with security reports, all Django Fello
 
 ## Membership management
 
-Each year, every non-Fellow member will need to reaffirm their membership with the team
-A non-Fellow member can leave for any reason at any time
+Each year, every non-Fellow member will need to reaffirm their membership with the team.
+A non-Fellow member can leave for any reason at any time. A Fellow whose contract ends is eligible to stay on the team if they would like.
 
 ### Reasons members can be removed from the team
 


### PR DESCRIPTION
Hi all (@django/django-security-team, @django/steering-council), here's a new draft of the Security Team charter that's available to review. There are a few changes highlighted to help us all be more effective and to help the team build for the future. I'd like to hear your opinions and concerns on what you think would work well and what won't.

The reason we're doing this with all the teams is to help the Fellows operate a bit more smoothly in our community. For other teams, it's defining a standard way to communicate with them and their expectations. That applies to the security team, but we'd like to explore dedicating people to a specific role too (see Report Triagers).

Proposed changes from existing operations:
- Creating report triager role for initial triaging of reports
- Generating an annual report
- Allowing people to self-nominate to join the security team
- Annual opt-in for members
- Creating chair and co-chair roles

### Creating report triager role
The goal here is to alleviate some of the daily workload from the Fellows. The Fellows are involved in many areas of the code base on a daily basis. They have a high awareness of what's going on and can help facilitate changes much more effectively than those who contribute less frequently.

The initial triaging of security reports is something that must be done which is why the Fellows are doing it. Helping maintain our security standards is one of their directives.

However, the initial review of a security report to determine if it's likely a valid report, what components it touches, and determining who likely will want to be involved doesn't require a Fellow. It requires legwork for someone to do the communication between the relevant parties.

Keep in mind, this change isn't necessarily asking an existing member to fill this role. If someone wants to be more active on the communication front, that's great. If not, we can recruit new team members and use this to set expectations for what their involvement would focus on.

### Generating an annual report
The purpose here is to help communicate with the broader community about your work and identify if other help is needed. It's possible there are security interested folks out there that would like to do the legwork to build out tooling to help the security team or security focused parts of the community. By bringing attention to it, we may be able to motivate newer contributors.

### Allowing members to self-nominate
There are a few reasons why this is being suggested:
- People who may be qualified who aren't in the personal network of the team, currently aren't eligible to join
- Some people may continue to be on this team because they think there's nobody to replace them
- Having a lower barrier to entry to join should lead to more new members, fresh ideas and energy to innovate
We can also change this again in the future if we find it's unhelpful or noisy. This doesn't need to be permanent, but it seems like something helpful to be explored.

### Creating a chair and co-chair role
With the addition of responsibilities that are ideally outside the Fellows purview, we'd want to identify one or two people who will help facilitate these actions. They also exist as the contact points for other teams.

## Other questions
- Does the team want to revise how to remove a member from the team? It currently states it requires full consensus from the other members
- Do you want to revisit the scope of responsibilities?

Thank you to @jefftriplett and @thibaudcolas for helping with the draft.