### PR TITLE
Draft: Proposal for marketing working group

### DIFF
--- a/active/marketing.md
+++ b/active/marketing.md
@@ -1,0 +1,78 @@
+# Marketing Working Group
+
+## Scope of responsibilities
+
+The working group is responsible for planning and execution of marketing activities, and for advising the DSF Board on strategic decisions related to marketing. The goal of those marketing activities is to:
+
+- Promote Django: to increase awareness, understanding, and adoption of the framework. And beyond the framework, to strengthen the public narrative about the project, its community, and the Django Software Foundation.
+- Ensure that Django is represented clearly and positively across all channels that are relevant to our audiences (such as developers, organisations, educators, open source contributors, etc).
+
+The group maintains key components of Django’s marketing strategy in accordance with guidance from the Board and Steering Council, and executes on that strategy autonomously. This includes maintaining:
+
+- The overall marketing strategy for Django and the DSF.
+- A website content strategy, including an editorial line for the blog.
+- Brand guidelines for Django and the DSF
+- KPIs aligned with objectives of the DSF
+
+Delegated responsibilities for the group to work on autonomously:
+
+- Management of the “www” djangoproject.com website content, in particular the Django blog and other content pages, excluding fundraising pages.
+- Management of one-off campaign sites like the [20th birthday site](https://birthday20.djangoproject.com/).
+
+Delegated responsibilities for the group to work on with others:
+
+- Management of fundraising pages on [djangoproject.com](http://djangoproject.com), in collaboration with the fundraising WG.
+- Contributions of marketing content to the “docs” [djangoproject.com](http://djangoproject.com) website content, in collaboration with Django core contributors.
+- Publication of new content across Django online community and social media channels, in collaboration with the Online Community WG and Social media WG.
+- Creation of physical and digital marketing collateral for Django events, and Django’s presence at events, in collaboration with the Events Support WG.
+
+## Initial membership
+
+- Chair: TBC
+- Co-Chair: TBC
+- Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair): TBC
+- Steering Council Liaison: TBC
+- Other members:
+  - Raffaella Suardini
+
+## Future membership
+
+We welcome everyone with an interest in marketing, and an understanding of the \[mission of the Django Software Foundation]. We select relevant volunteers based on our understanding of gaps in the group’s expertise.
+
+## ### How do people who want to join sign up / volunteer / express interest?
+
+To apply to join the group, fill our \[marketing working group application form].
+
+## ### How will decisions on adding/removing members be handled?
+
+Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members. The WG will vote for New Chair/Co-Chairs and decision to appoint will be based on gaining majority votes.
+
+Members join the group for one year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
+
+Members can be removed from the group with a 50%+1 vote from other members.
+
+### Access granting and deployment
+
+New members join the group with no access to the website’s content publishing functionality. After 6 months of onboarding, they can request publishing access to the Chair and Co-Chair, who decide whether the onboarding is completed, and if so liaise with the \[ops team] to manage permissions.
+
+For content managed via hard-coded templates within the website repository, contributions are made via the standard pull request process. Content changes are reviewed by other group members, with a final quality check by the \[website WG] before merging.
+
+## Budget
+
+No allocated budget. The group will likely request a budget to hire external marketing experts in the future.
+
+## Communications
+
+1. Group-only private channel in the DSF slack
+2. Shared #marketing public channel for all DSF slack members
+3. TBC: shared channel with fundraising and website WG members
+4. TBC: Channels to be identified on the Django Forum and Discord server
+5. Private group mailing list for internal communications only
+
+## Reporting
+
+We post public meeting notes to the forum, with private information (such as in-progress partnerships) left out. The DSF Board and Steering Council have access to the group’s full private meeting notes.
+
+For campaigns, we share a tracker with all DSF volunteers.
+
+The team produces an annual report that is shared publicly with the Django community.

--- a/active/marketing.md
+++ b/active/marketing.md
@@ -16,13 +16,13 @@ The group maintains key components of Django’s marketing strategy in accordanc
 
 Delegated responsibilities for the group to work on autonomously:
 
-- Management of the “www” djangoproject.com website content, in particular the Django blog and other content pages, excluding fundraising pages.
+- Management of the "www" djangoproject.com website content, in particular the Django blog and other content pages, excluding fundraising pages.
 - Management of one-off campaign sites like the [20th birthday site](https://birthday20.djangoproject.com/).
 
 Delegated responsibilities for the group to work on with others:
 
 - Management of fundraising pages on [djangoproject.com](http://djangoproject.com), in collaboration with the fundraising WG.
-- Contributions of marketing content to the “docs” [djangoproject.com](http://djangoproject.com) website content, in collaboration with Django core contributors.
+- Contributions of marketing content to the "docs" [djangoproject.com](http://djangoproject.com) website content, in collaboration with Django core contributors.
 - Publication of new content across Django online community and social media channels, in collaboration with the Online Community WG and Social media WG.
 - Creation of physical and digital marketing collateral for Django events, and Django’s presence at events, in collaboration with the Events Support WG.
 
@@ -37,13 +37,13 @@ Delegated responsibilities for the group to work on with others:
 
 ## Future membership
 
-We welcome everyone with an interest in marketing, and an understanding of the \[mission of the Django Software Foundation]. We select relevant volunteers based on our understanding of gaps in the group’s expertise.
+We welcome everyone with an interest in marketing, and an understanding of the [goals of the Django Software Foundation](https://www.djangoproject.com/foundation/). We select relevant volunteers based on our understanding of gaps in the group’s expertise.
 
-## ### How do people who want to join sign up / volunteer / express interest?
+### How do people who want to join sign up / volunteer / express interest?
 
 To apply to join the group, fill our \[marketing working group application form].
 
-## ### How will decisions on adding/removing members be handled?
+### How will decisions on adding/removing members be handled?
 
 Direct membership: new members may self-nominate; the WG will vote (50%+1) to approve/deny new members. The WG will vote for New Chair/Co-Chairs and decision to appoint will be based on gaining majority votes.
 
@@ -53,20 +53,23 @@ Members can be removed from the group with a 50%+1 vote from other members.
 
 ### Access granting and deployment
 
-New members join the group with no access to the website’s content publishing functionality. After 6 months of onboarding, they can request publishing access to the Chair and Co-Chair, who decide whether the onboarding is completed, and if so liaise with the \[ops team] to manage permissions.
+New members join the group with no access to the website’s content publishing functionality. After 6 months of onboarding, they can request publishing access to the Chair, Co-Chair, Board Liaison, who decide whether the onboarding is completed, and if so liaise with the [ops team](https://www.djangoproject.com/foundation/teams/#ops-team) to manage permissions.
 
-For content managed via hard-coded templates within the website repository, contributions are made via the standard pull request process. Content changes are reviewed by other group members, with a final quality check by the \[website WG] before merging.
+For content managed via hard-coded templates within the website repository, contributions are made via pull requests. Content changes are reviewed by other group members, with a final quality check by the \[website working group](https://www.djangoproject.com/foundation/teams/#website-team) before merging.
 
 ## Budget
 
-No allocated budget. The group will likely request a budget to hire external marketing experts in the future.
+No allocated budget. Once created, the group will likely request a budget to:
+
+- Hire external marketing experts
+- Procure relevant tools (for example design software)
 
 ## Communications
 
 1. Group-only private channel in the DSF slack
 2. Shared #marketing public channel for all DSF slack members
 3. TBC: shared channel with fundraising and website WG members
-4. TBC: Channels to be identified on the Django Forum and Discord server
+4. TBC: channels to be identified on the Django Forum and Discord server
 5. Private group mailing list for internal communications only
 
 ## Reporting

--- a/active/marketing.md
+++ b/active/marketing.md
@@ -2,10 +2,17 @@
 
 ## Scope of responsibilities
 
-The working group is responsible for planning and execution of marketing activities, and for advising the DSF Board on strategic decisions related to marketing. The goal of those marketing activities is to:
+The working group is responsible for:
+
+* Planning and execution of marketing activities
+* Proposing new strategies for marketing activities
+* Advising the DSF Board on strategic decisions related to marketing and strategic communication
+
+The goals of those marketing activities are:
 
 - Promote Django: to increase awareness, understanding, and adoption of the framework. And beyond the framework, to strengthen the public narrative about the project, its community, and the Django Software Foundation.
 - Ensure that Django is represented clearly and positively across all channels that are relevant to our audiences (such as developers, organisations, educators, open source contributors, etc).
+- Increasing strategic coherence of activities across our communication channels
 
 The group maintains key components of Django’s marketing strategy in accordance with guidance from the Board and Steering Council, and executes on that strategy autonomously. This includes maintaining:
 
@@ -16,7 +23,7 @@ The group maintains key components of Django’s marketing strategy in accordanc
 
 Delegated responsibilities for the group to work on autonomously:
 
-- Management of the "www" djangoproject.com website content, in particular the Django blog and other content pages, excluding fundraising pages.
+- Management of the "www" djangoproject.com website content, in particular the Django blog and other channels that are closely related to marketing.
 - Management of one-off campaign sites like the [20th birthday site](https://birthday20.djangoproject.com/).
 
 Delegated responsibilities for the group to work on with others:


### PR DESCRIPTION
[View the proposed charter](https://github.com/thibaudcolas/dsf-working-groups/blob/marketing-wg/active/marketing.md). This is a draft charter written by @sabderemane and I for a new Marketing working group for Django, in charge of both strategy and execution. It’s inspired by our website and social media working groups, though this is a bit more complex as marketing overlaps with a lot of existing teams’ remit. 

- Marketing work has to be coordinated with a lot of other aspects of the project / foundation
- It needs a lot of strategic thinking at times, and a lot of just pure execution at other times
- Lots of the execution relies on having access to relatively sensitive systems (website publishing, social media)
- The execution also relies on the group having enough autonomy when possible, and enough stakeholder review when needed

## Proposal status

The draft attempts to balance all of the above, hopefully making it clear enough when we can have this group be autonomous and when to otherwise coordinate. We need more people with more capacity than @sabderemane and I to take this further. We thought creating the draft might help.