### PR TITLE
Add Google Summer of Code Working Group charter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Foundation to be accessible to as many people as possible.
 - [Events support](active/events-support.md) — supports organizers of Django-related events globally, including DjangoCon conferences.
 - [Fellowship](active/fellowship.md) — manages the operation of the Django Fellowship program.
 - [Fundraising](active/fundraising.md) — coordinates fundraising efforts, particularly around corporate and major donations.
+- [Google Summer of Code](active/google-summer-of-code.md) — coordinates and organizes Django's participation in the Google Summer of Code program.
 - [Online Community](active/online-community.md) — support the official community platforms and those in elevated roles on those platforms.
 - [Social Media](active/social-media.md) — manages Django's official social media profiles.
 - [Website](active/website.md) — maintains and manages the djangoproject.com website.

--- a/active/google-summer-of-code.md
+++ b/active/google-summer-of-code.md
@@ -10,6 +10,7 @@ Delegated responsibilities:
 - Communicate and coordinate with GSoC officials on behalf of the Django community.
 - Identify projects and mentors for Django projects across the community.
 - Communicate and coordinate with prospective mentees and mentors.
+- Communicate and coordinate with Django community regarding GSoC.
 
 ## Initial membership
 

--- a/active/google-summer-of-code.md
+++ b/active/google-summer-of-code.md
@@ -1,0 +1,61 @@
+# Google Summer of Code Working Group
+
+## Scope of responsibilities
+
+This working group coordinates and organizes Django's participating with [Google Summer of Code (GSoC)](https://summerofcode.withgoogle.com/).
+
+The goal of the group is to support and facilitate Django's participation in Google Summer of Code as an organization.
+
+Delegated responsibilities:
+- Communicate and coordinate with GSoC officials on behalf of the Django community.
+- Identify projects and mentors for Django projects across the community.
+- Communicate and coordinate with prospective mentees and mentors.
+
+## Initial membership
+
+- Chair: Bhuvnesh Sharma
+- Co-Chair: Apoorv Garg
+- Board Liaison:
+- Steering Council Liaison:
+- Other members:
+
+## Future membership
+
+Anyone who has interest in Django, coordinating community members and/or encouraging contributions to Django is welcome to join. We welcome all experience levels.
+
+### Expressing Interest
+
+Send one of the WG members a message on Discord or the Forum. A form will be made available in a public space with the following questions:
+
+* Usernames on the Forum/Discord.
+* Why they want to join.
+* What experience and skills they bring to the WG.
+
+### Membership Conditions
+
+  - New members may self-nominate.
+  - Members will serve for a one year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
+  - New members will get approved by existing members of the WG.
+  - If any member wishes to leave the group before the end of their term, they can do so by notifying the group.
+  - Members can propose a vote on removing a member from the working group. This needs 50%+1 agreement.
+
+### Roles in within WG
+
+ - Chair/Co-chair: The chair and co-chair are responsible for coordinating the community for the GSoC program.
+ - Board Liaison: Must be an active Board member; may be the same as Chair/Co-Chair.
+ - Steering Council Liaison: Must be an active Steering Council member; may be the same as Chair/Co-Chair.
+
+## Budget
+
+No budget is required at this time. This will be reviewed at least annually.
+Any changes to the budget may be requested from the board.
+
+## Comms
+
+Discussions will take place on the [Django Discord](https://chat.djangoproject.com) in the private #gsoc-organization channel.
+
+## Reporting
+
+An annual report will be produced highlighting the GSoC project(s) of the year. There may be one per project that is written by the mentees.
+
+The program's documentation and notes will be maintained in Django's Google Drive folder, [Google Summer of Code (GSoC)](https://drive.google.com/drive/folders/1g-j683JwHlIFMTR_E4_NM1_ykRfvq_nA?usp=drive_link).

--- a/active/google-summer-of-code.md
+++ b/active/google-summer-of-code.md
@@ -12,31 +12,27 @@ Delegated responsibilities:
 - Communicate and coordinate with prospective mentees and mentors.
 - Communicate and coordinate with Django community regarding GSoC.
 
-## Initial membership
+## Membership
 
 - Chair: Bhuvnesh Sharma
 - Co-Chair: Apoorv Garg
 - Board Liaison:
-- Steering Council Liaison:
+- Steering Council Liaison: Tim Schilling
 - Other members:
 
 ## Future membership
 
 Anyone who has interest in Django, coordinating community members and/or encouraging contributions to Django is welcome to join. We welcome all experience levels.
 
+
 ### Expressing Interest
 
-Send one of the WG members a message on Discord or the Forum. A form will be made available in a public space with the following questions:
-
-* Usernames on the Forum/Discord.
-* Why they want to join.
-* What experience and skills they bring to the WG.
+If you are interested in joining, please use our form: [Apply to join the GSoC working group](https://forms.gle/XGSNLCWpGxvqPW4DA).
 
 ### Membership Conditions
 
-  - New members may self-nominate.
-  - Members will serve for a one year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
   - New members will get approved by existing members of the WG.
+  - Members will serve for a one-year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
   - If any member wishes to leave the group before the end of their term, they can do so by notifying the group.
   - Members can propose a vote on removing a member from the working group. This needs 50%+1 agreement.
 
@@ -53,7 +49,13 @@ Any changes to the budget may be requested from the board.
 
 ## Comms
 
-Discussions will take place on the [Django Discord](https://chat.djangoproject.com) in the private #gsoc-organization channel.
+Discussions will take place on the [Django Discord](https://chat.djangoproject.com) in the private #gsoc-organization channel. They will have mailing list at gsoc@djangoproject.com to be included on any outreach activities from a member on behalf of the WG.
+
+The WG can be tagged as follows:
+
+- Discord: @gsoc-wg
+- Forum: @gsoc-wg
+- GitHub: @django/gsoc-wg
 
 ## Reporting
 

--- a/active/google-summer-of-code.md
+++ b/active/google-summer-of-code.md
@@ -16,7 +16,7 @@ Delegated responsibilities:
 
 - Chair: Bhuvnesh Sharma
 - Co-Chair: Apoorv Garg
-- Board Liaison:
+- Board Liaison: Jeff Triplett
 - Steering Council Liaison: Tim Schilling
 - Other members:
     - Sarah Boyce

--- a/active/google-summer-of-code.md
+++ b/active/google-summer-of-code.md
@@ -19,6 +19,7 @@ Delegated responsibilities:
 - Board Liaison:
 - Steering Council Liaison: Tim Schilling
 - Other members:
+    - Sarah Boyce
 
 ## Future membership
 
@@ -31,16 +32,16 @@ If you are interested in joining, please use our form: [Apply to join the GSoC w
 
 ### Membership Conditions
 
-  - New members will get approved by existing members of the WG.
-  - Members will serve for a one-year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
-  - If any member wishes to leave the group before the end of their term, they can do so by notifying the group.
-  - Members can propose a vote on removing a member from the working group. This needs 50%+1 agreement.
+- New members will get approved by existing members of the WG.
+- Members will serve for a one-year term. At the end of this term, they need to opt into staying involved to keep being a member of the group.
+- If any member wishes to leave the group before the end of their term, they can do so by notifying the group.
+- Members can propose a vote on removing a member from the working group. This needs 50%+1 agreement.
 
 ### Roles in within WG
 
- - Chair/Co-chair: The chair and co-chair are responsible for coordinating the community for the GSoC program.
- - Board Liaison: Must be an active Board member; may be the same as Chair/Co-Chair.
- - Steering Council Liaison: Must be an active Steering Council member; may be the same as Chair/Co-Chair.
+- Chair/Co-chair: The chair and co-chair are responsible for coordinating the community for the GSoC program.
+- Board Liaison: Must be an active Board member; may be the same as Chair/Co-Chair.
+- Steering Council Liaison: Must be an active Steering Council member; may be the same as Chair/Co-Chair.
 
 ## Budget
 


### PR DESCRIPTION
This is a first draft of the charter. I tried to keep it inline with current efforts. I expect as the WG forms and iterates, it will be more ambitious and the scope will change.

cc: @DevilsAutumn @Apoorvgarg-creator