### PR TITLE
Added Mergers team charter.

### DIFF
--- a/active/mergers.md
+++ b/active/mergers.md
@@ -11,6 +11,7 @@ Mergers will:
   - The PR is for one of the following scenarios:
       - An accepted ticket.
       - An approved new feature.
+      - A trivial clean-up to such as fixing failing tests or merge mistake.
       - The changes are tests additions.
       - The changes are documentation fixes.
   - The PR is approved by one of the following:
@@ -25,7 +26,7 @@ Mergers will:
 - Request the Steering Council to vote on a decision that fails to reach consensus if a decision is needed.
 - Perform backports of changes merged into the `main` branch to the stable branches following the [backporting policy](https://docs.djangoproject.com/en/dev/internals/release-process/#supported-versions).
 
-## Initial membership
+## Membership
 
 - Chair:
 - Co-Chair:

--- a/active/mergers.md
+++ b/active/mergers.md
@@ -1,0 +1,63 @@
+# Mergers Team
+
+## Scope of responsibilities
+
+Mergers are a small set of people who merge pull requests to the [Django git repository](https://github.com/django/django/).
+
+Mergers will:
+- Merge pull requests when they can have determined that:
+  - The PR meets the documented code quality guidelines.
+  - A DEP is approved or not needed.
+  - The PR is for one of the following scenarios:
+      - An accepted ticket.
+      - An approved new feature.
+      - The changes are tests additions.
+      - The changes are documentation fixes.
+  - The PR is approved by one of the following:
+    - Another Merger.
+    - A member of the [Triage & Review team](https://www.djangoproject.com/foundation/teams/#triage-review-team).
+    - A member of the [Security Team](https://www.djangoproject.com/foundation/teams/#security-team).
+- Initiate discussion of a minor change in the appropriate venue, and request that other Mergers refrain from merging it while discussion proceeds.
+- Requesting a vote of the steering council regarding any minor change if, in the Merger’s opinion, discussion has failed to reach a consensus.
+- Requesting a vote of the steering council when a major change (significant enough to require the use of the DEP process) reaches one of its implementation milestones and is intended to merge.
+- Merge changes when the [Security Team](./security.md) directs pull requests or specific patches to be merged.
+- Share knowledge and propose documentation changes about undocumented code quality or consistency practices.
+- Request the Steering Council to vote on a decision that fails to reach consensus if a decision is needed.
+- Perform backports of changes merged into the `main` branch to the stable branches following the [backporting policy](https://docs.djangoproject.com/en/dev/internals/release-process/#supported-versions).
+
+## Initial membership
+
+- Chair:
+- Co-Chair:
+- [Optional] Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair):
+- Other members:
+  - Claude Paroz
+  - Jacob Walls
+  - Mariusz Felisiak
+  - Natalia Bidart
+  - Sarah Boyce
+
+## Future membership
+
+The [Steering Council](https://www.djangoproject.com/foundation/teams/#steering-council-team) selects Mergers by voting. If the team determines it needs new members, a call for volunteers will be posted on the [djangoproject.com blog](https://www.djangoproject.com/weblog/) and the [Django Forum](https://forum.djangoproject.com).
+
+The membership will operate as follows:
+- All Django Fellows are automatically added to the Mergers team
+- A Django Fellow contract termination removes the person from the Mergers team
+- There should be at least three members at all times
+- There is no upper limit to the number of Mergers
+- Each year, every non-Fellow member will need to reaffirm their membership with the team
+
+## Budget
+
+There is no budget, but requests can be made to the Board as needs arise.
+
+## Comms
+
+The team can be mentioned in the following ways:
+
+- [GitHub team](https://github.com/orgs/django/teams/mergers)
+
+## Reporting
+
+The team does not produce reports at this time.

--- a/active/mergers.md
+++ b/active/mergers.md
@@ -11,7 +11,7 @@ Mergers will:
   - The PR is for one of the following scenarios:
       - An accepted ticket.
       - An approved new feature.
-      - A trivial clean-up to such as fixing failing tests or merge mistake.
+      - A trivial clean-up such as fixing failing tests or merge mistake.
       - The changes are tests additions.
       - The changes are documentation fixes.
   - The PR is approved by a community member

--- a/active/mergers.md
+++ b/active/mergers.md
@@ -14,10 +14,11 @@ Mergers will:
       - A trivial clean-up to such as fixing failing tests or merge mistake.
       - The changes are tests additions.
       - The changes are documentation fixes.
-  - The PR is approved by one of the following:
+  - The PR is approved by a community member
+  - If the merger has authored the PR, then another approval is required by one of the following:
     - Another Merger.
     - A member of the [Triage & Review team](https://www.djangoproject.com/foundation/teams/#triage-review-team).
-    - A member of the [Security Team](https://www.djangoproject.com/foundation/teams/#security-team).
+    - A member of the [Security Team](https://www.djangoproject.com/foundation/teams/#security-team), but only if the PR is related to a reported vulnerability.
 - Initiate discussion of a minor change in the appropriate venue, and request that other Mergers refrain from merging it while discussion proceeds.
 - Requesting a vote of the steering council regarding any minor change if, in the Merger’s opinion, discussion has failed to reach a consensus.
 - Requesting a vote of the steering council when a major change (significant enough to require the use of the DEP process) reaches one of its implementation milestones and is intended to merge.


### PR DESCRIPTION
This is part of the DSF's effort to standarize the technical teams.

This moves the team's governance from DEP 10 into the working groups structure. The new governance is a bit slimmer and should provide more flexibility to the teams.

References #28