### PR TITLE
Added Releasers team charter.

### DIFF
--- a/active/releasers.md
+++ b/active/releasers.md
@@ -8,7 +8,7 @@ Releasers will:
 - Follow the documented [release process](https://docs.djangoproject.com/en/dev/internals/howto-release-django/) and [cadence](https://github.com/django/deps/blob/main/final/0044-clarify-release-process.rst)
 - Coordinate with the [Security Team](./security.md) to schedule security releases
 
-## Initial membership
+## Membership
 
 - Chair:
 - Co-Chair:

--- a/active/releasers.md
+++ b/active/releasers.md
@@ -29,7 +29,7 @@ The membership will operate as follows:
 - There should be at least three members at all times
 - There is no upper limit to the number of Releasers
 - Each year, every non-Fellow member will need to reaffirm their membership with the team
-- A releaser needs to be a merger as the release process involves making commits
+- If a member is not on the [Mergers Team](https://www.djangoproject.com/foundation/teams/#mergers-team), they must only use their merge rights for merging administrative commits related to releases
 
 ## Budget
 

--- a/active/releasers.md
+++ b/active/releasers.md
@@ -1,0 +1,46 @@
+# Releasers Team
+
+## Scope of responsibilities
+
+Releasers take care of [building Django releases](https://docs.djangoproject.com/en/dev/internals/howto-release-django/). They have the authority to upload Django release artifacts to the [Python Package Index](https://pypi.org/project/Django/) and to the [djangoproject.com](https://www.djangoproject.com/download/) website.
+
+Releasers will:
+- Follow the documented [release process](https://docs.djangoproject.com/en/dev/internals/howto-release-django/) and [cadence](https://github.com/django/deps/blob/main/final/0044-clarify-release-process.rst)
+- Coordinate with the [Security Team](./security.md) to schedule security releases
+
+## Initial membership
+
+- Chair:
+- Co-Chair:
+- [Optional] Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair):
+- Other members:
+  - Jacob Walls
+  - Mariusz Felisiak
+  - Natalia Bidart
+  - Sarah Boyce
+
+## Future membership
+
+The [Steering Council](https://www.djangoproject.com/foundation/teams/#steering-council-team) selects Releasers by voting. If the team determines it needs new members, a call for volunteers will be posted on the [djangoproject.com blog](https://www.djangoproject.com/weblog/) and the [Django Forum](https://forum.djangoproject.com).
+
+The membership will operate as follows:
+- All Django Fellows are automatically added to the Releasers team
+- A Django Fellow contract termination removes the person from the Releasers team
+- There should be at least three members at all times
+- There is no upper limit to the number of Releasers
+- Each year, every non-Fellow member will need to reaffirm their membership with the team
+- A releaser needs to be a merger as the release process involves making commits
+
+## Budget
+
+There is no budget, but requests can be made to the Board as needs arise.
+
+## Comms
+
+The team can be mentioned in the following ways:
+
+- [GitHub team](https://github.com/orgs/django/teams/releasers)
+
+## Reporting
+
+The team does not produce reports at this time.


### PR DESCRIPTION
This is part of the DSF's effort to standarize the technical teams.

This moves the team's governance from DEP 10 into the working groups structure. The new governance is a bit slimmer and should provide more flexibility to the teams.

References #28 