### PR TITLE
Added Operations team charter.

### DIFF
--- a/active/operations.md
+++ b/active/operations.md
@@ -70,7 +70,7 @@ There is no dedicated budget at this time, but funds can be requested from the B
 
 ## Comms
 
-The team communications and can be contacted via the [ops@djangoproject.com](mailto:ops@djangoproject.com) email.
+The team communicates and can be contacted via the [ops@djangoproject.com](mailto:ops@djangoproject.com) email.
 
 The team can be mentioned in the following ways:
 

--- a/active/operations.md
+++ b/active/operations.md
@@ -1,0 +1,87 @@
+# Operations Team
+
+## Scope of responsibilities
+
+The Operations (Ops) Team is responsible for managing the DSF's core infrastructure, hosting and software-as-a-service providers, and sensitive matters such as credentials. The dedicated team helps limit attack surface area and limit impact of incidents.
+
+The Ops team manages several platforms:
+- The server running [djangoproject.com](https://djangoproject.com) and [Django's Trac instance](https://code.djangoproject.com/)
+- The [Jenkins server for CI](https://djangoci.com/)
+
+The Ops team also helps manage several applications due to their privileged access:
+
+- The [Django GitHub organization](https://github.com/django)
+- The [DjangoCon GitHub organization](https://github.com/djangocon)
+- Hosting providers
+- Content Delivery Network
+- Secret management
+
+The Ops team is able to make the following decisions based on their judgement:
+
+- Software and OS upgrades (major and minor)
+- Updates to or migrations between established service providers
+- Performance improvements
+- Bug fixes
+- Backwards compatible changes
+- Access control requests
+- DNS changes
+
+The Ops team will request Board approval before moving forward any other decision.
+
+## Initial membership
+
+- [Optional] Board Liaison (must be an active Board member; may be the same as Chair/Co-Chair):
+- Members:
+    - Baptiste Mispelon
+    - Mariusz Felisiak
+    - Markus Holtermann
+    - Natalia Bidart
+    - Sarah Boyce
+    - Tobias McNulty
+
+## Future membership
+
+The team manages its own membership by invitation. If the team needs to make a call for volunteers, it will be posted on the [djangoproject.com blog](https://www.djangoproject.com/weblog/) and the [Django Forum](https://forum.djangoproject.com).
+
+The membership will operate as follows:
+- Django Fellows are included in the Ops team mailing list for awareness, and are invited to be part of the Ops team
+- A Django Fellow contract termination removes the person from the Ops team
+- There should be at least three members at all times
+- There is no upper limit to the number of members
+- Each year, every member will need to reaffirm their membership with the team
+
+### Qualifications
+
+The primary qualification for Ops team members is trust. The person must be trusted with the highest level of access in the community. This means they need to have a steady, extensive track record of good decision-making and dedication to the community.
+
+From a technical perspective members are expected to have knowledge in the following areas:
+
+- DevOps experience (Ansible, AWS, OpenStack)
+- DNS management
+- Linux server administration
+- Docker/Podman
+- PostgreSQL
+
+
+
+## Budget
+
+The Ops team manages USD $100,000-plus worth of infrastructure through in-kind donations from DSF sponsors.
+
+There is no dedicated budget at this time, but funds can be requested from the Board.
+
+## Comms
+
+The team communications and can be contacted via the [ops@djangoproject.com](mailto:ops@djangoproject.com) email.
+
+The team can be mentioned in the following ways:
+
+- [GitHub team](https://github.com/orgs/django/teams/ops-team)
+
+The team meets monthly via Meet.
+
+The team has a private channel on the [Django Discord server](https://chat.djangoproject.com).
+
+## Reporting
+
+The team does not produce reports at this time.

--- a/active/operations.md
+++ b/active/operations.md
@@ -70,7 +70,7 @@ There is no dedicated budget at this time, but funds can be requested from the B
 
 ## Comms
 
-The team communicates and can be contacted via the [ops@djangoproject.com](mailto:ops@djangoproject.com) email.
+The team can be contacted via the [ops@djangoproject.com](mailto:ops@djangoproject.com) email.
 
 The team can be mentioned in the following ways:
 

--- a/active/operations.md
+++ b/active/operations.md
@@ -62,8 +62,6 @@ From a technical perspective members are expected to have knowledge in the follo
 - Docker/Podman
 - PostgreSQL
 
-
-
 ## Budget
 
 The Ops team manages USD $100,000-plus worth of infrastructure through in-kind donations from DSF sponsors.


### PR DESCRIPTION
This is part of the DSF's effort to standarize the technical teams.

The Ops team didn't have much in the way of written governance in the past. The expectation is that this will help future team members get onboarded. The expectations will also help the DSF Board and other groups support the team.

References https://github.com/django/dsf-working-groups/issues/28