### PR TITLE
Renamed "Membership" section titles across charters and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ultimately, the information that needs to be in the charter is:
   - What powers are you asking the board to delegate to you?
   - What actions are you proposing the WG be allowed to take directly?
   - Which actions will the WG take back to the Board for votes?
-- **Initial membership** - who will be in this working group when it's first created?
+- **Membership** - who will be in this working group when it's first created?
   - **Board of liaison** - the person will be the bridge between the DSF board and the working group. It will be someone who will keep the vision of the board in the working group and have the same rights as a member of the working group.
   - **Steering Council liaison** - the person will be the bridge between the Steering Council and the working group. It will be someone who will keep the vision of the Steering Council in the working group and have the same rights as a member of the working group. This is only for teams and is only optional.
   - **Every working group should have at least one active Board member**. It's best if you already know who this is. It's OK if you don't, but if nobody from the Board volunteers, we can't create your working group. We'll refer to this person as the WG's "Board Liaison". A Board Liason is optional for teams and required for working groups.

--- a/active/events-support.md
+++ b/active/events-support.md
@@ -18,7 +18,7 @@ For DjangoCon events, the working group will:
 - Work with DjangoCon Africa organizers to make this event sustainable.
 - Work with the Social Media Working Group to promote events
 
-## Initial membership
+## Membership
 
 The group has a small initial membership, with the goal of expanding to 7-10 members able to represent
 

--- a/active/fellowship.md
+++ b/active/fellowship.md
@@ -30,7 +30,7 @@ Upon adoption of this new charter, the Board will issue an open call for members
 
 The board liaison will act as chair through this transition, util the full membership is approved and all roles filled out.
 
-## Members
+## Membership
 
 - Chair: Tom Carrick
 - Co-Chair: TBD

--- a/active/fundraising.md
+++ b/active/fundraising.md
@@ -17,7 +17,7 @@ Delegated responsibilities:
 - Management of the djangoproject.com website content and other marketing collateral relating to fundraising
 
 
-## Initial membership
+## Membership
 
 - Chair: Thibaud Colas
 - Co-Chair: Priya Pahwa

--- a/active/online-community.md
+++ b/active/online-community.md
@@ -37,7 +37,7 @@ With regards to Django Software Foundation responsibilities and resources, the m
   - A single member may not have Administrator Privileges on all platforms.
   - Each platform has a minimum of two members with Administrator Privileges.
 
-## Initial membership
+## Membership
 
 - Chair: Andrew Miller
 - Co-Chair: Ben Cardy

--- a/active/social-media.md
+++ b/active/social-media.md
@@ -31,7 +31,7 @@ Actions to take back to the DSF Board for votes:
 - Proposal to have a new social media profile on a platform.
 - Proposal to retire a social media profile from a platform.
 
-## Initial membership
+## Membership
 
 - Chair: Benjamin Balder Bach
 - Co-Chair: Bhuvnesh Sharma 

--- a/active/website.md
+++ b/active/website.md
@@ -15,7 +15,7 @@ The duties of the working group are:
 - Run or support djangoproject.com sessions in DjangoCon sprints.
 - Chair, Co-Chair and Board Liaison can sign off on new features.
 
-## Initial membership
+## Membership
 
 - Chair: Sarah Abderemane
 - Co-Chair: Saptak Sengupta

--- a/archive/dceu.md
+++ b/archive/dceu.md
@@ -6,7 +6,7 @@ Supports organizers of DjangoCon Europe.
 
 Delegated responsibilities TBD.
 
-## Initial membership
+## Membership
 
 - Chair: Tobias Kunze
 - Co-Chair: Raphael Michel

--- a/team-template.md
+++ b/team-template.md
@@ -13,7 +13,7 @@ Please link any relevant documentation.
 - Which actions will the team/WG take back to the Board for votes, if any?
 - Which actions will the team/WG take back to the Steering Council for votes, if any?
 
-## Initial membership
+## Membership
 
 - Chair:
 - Co-Chair:

--- a/template.md
+++ b/template.md
@@ -10,7 +10,7 @@ Write a paragraph or a few bullet points describing the WG here.
 - What actions are you proposing the WG be allowed to take directly?
 - Which actions will the WG take back to the Board for votes?
 
-## Initial membership
+## Membership
 
 - Chair:
 - Co-Chair:


### PR DESCRIPTION
The origin of this PR stems from [this PR / comment](https://github.com/django/dsf-working-groups/pull/68#pullrequestreview-3706938561). It aims to address this problem:

> Initial membership really only works for the proposal, once it's accepted it's out of date

I noticed some of the charters already had "Membership" instead of "Initial Membership" so I changed the ones that weren't already "Membership" to match that title (instead of changing them all to "Current Membership"). Doing that still addresses the problem with "Initial" but keeps it consistent with what some groups have already done.