### PR TITLE
Remove duplicate entry for Natalia Bidart

### DIFF
--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -17,7 +17,6 @@ See https://github.com/django/code-of-conduct for full details.
 - Natalia Bidart, Online Communities WG Liason
 - Priya Pahwa
 - Thibaud Colas
-- Natalia Bidart, liason for Online Communities working group
 
 ## Future membership
 


### PR DESCRIPTION
Removed duplicate entry for Natalia Bidart in the code of conduct.