### PR TITLE
Update events support WG membership

### DIFF
--- a/active/events-support.md
+++ b/active/events-support.md
@@ -28,11 +28,11 @@ Current members:
 
 - Chair: Thibaud Colas
 - Co-Chair: David Vaz
-- Board Liaison: Thibaud Colas
+- Board Liaison: Paolo Melchiorre
 - Other members:
   - Theresa Seyram Agbenyegah
   - Benjamin Balder Bach
-  - You?
+  - Çağıl Uluşahin Sönmez
 
 ## Future membership
 


### PR DESCRIPTION
Thank you @pauloxnet for joining as Board Liaison ⭐️ and @cgl as a member.

Once this is merged, we need:

- [x] Someone with website permissions to update the Team membership at https://www.djangoproject.com/admin/members/team/10/change/
- [x] Someone with Google Workspace permissions to update the Google Group (both Çağıl and Paolo already have @djangoproject.com emails so should be simple)
