### PR TITLE
Revise membership roles in code of conduct

### DIFF
--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -11,7 +11,7 @@ See https://github.com/django/code-of-conduct for full details.
 <!-- Keep the membership in sync between the GitHub team, https://github.com/django/code-of-conduct/blob/main/membership.md, https://github.com/django/dsf-working-groups/blob/main/active/code-of-conduct.md, https://www.djangoproject.com/foundation/committees/ -->
 
 - Dan Ryan, Chair
-- Natalia Bidart, Co-chair & Online Communities WG Liason
+- Natalia Bidart, Vice-chair & Online Communities WG Liason
 - Ariane Djeupang
 - Jeff Triplett, DSF Board President and board liaison
 - Priya Pahwa

--- a/active/code-of-conduct.md
+++ b/active/code-of-conduct.md
@@ -11,12 +11,10 @@ See https://github.com/django/code-of-conduct for full details.
 <!-- Keep the membership in sync between the GitHub team, https://github.com/django/code-of-conduct/blob/main/membership.md, https://github.com/django/dsf-working-groups/blob/main/active/code-of-conduct.md, https://www.djangoproject.com/foundation/committees/ -->
 
 - Dan Ryan, Chair
-- Elena Williams, Vice-Chair
+- Natalia Bidart, Co-chair & Online Communities WG Liason
 - Ariane Djeupang
 - Jeff Triplett, DSF Board President and board liaison
-- Natalia Bidart, Online Communities WG Liason
 - Priya Pahwa
-- Thibaud Colas
 
 ## Future membership
 


### PR DESCRIPTION
Updated membership roles in the code of conduct. Addresses https://github.com/django/code-of-conduct/issues/113 and https://github.com/django/code-of-conduct/issues/112