### PR TITLE
Add SiHyun Lee (Antoliny) to Accessibility Working Group

### DIFF
--- a/active/accessibility.md
+++ b/active/accessibility.md
@@ -57,6 +57,7 @@ requests.
   - Sage Abdullah
   - Saptak Sengupta
   - Sarah Abderemane
+  - SiHyun Lee
   - Thibaud Colas
 
 ### Alumni


### PR DESCRIPTION
The Accessibility Working Group is happy to welcome a new member to the team, SiHyun Lee (Antoliny), who has already made significant contributions in Django a11y. This was voted and agreed upon within the A11Y WG Discord. 